### PR TITLE
make it possible to avoid inline linebreaks

### DIFF
--- a/lib/textile.js
+++ b/lib/textile.js
@@ -148,8 +148,10 @@
 
   var options = {};
   function set_options ( opt ) {
-    // no options supported yet
-    options = {};
+    options = {
+      // single-line linebreaks are converted to <br> by default
+      breaks: (opt.breaks === undefined ? true : opt.breaks)
+    };
   }
 
 
@@ -823,7 +825,10 @@
       // linebreak -- having this first keeps it from messing to much with other phrases
       if ( src.startsWith( '\n' ) ) {
         src.advance( 1 );
-        list.add( [ 'br' ] );
+
+        if(options.breaks) {
+          list.add( [ 'br' ] );
+        }
         list.add( '\n' );
         continue;
       }
@@ -1243,14 +1248,14 @@
   /* exposed */
 
   function textile ( txt, opt ) {
-    set_options( opt );
+    set_options( opt || {} );
     var o = parse_blocks( txt ).map( JSONML.toHTML ).join( '' );
     return o;
   }
   textile.parse = textile.convert = textile;
   textile.html_parser = parse_html;
   textile.jsonml = function ( txt, opt ) {
-    set_options( opt );
+    set_options( opt || {} );
     return [ 'html' ].concat( parse_blocks( txt ) );
   };
   textile.serialize = JSONML.toHTML;

--- a/test/index.html
+++ b/test/index.html
@@ -26,6 +26,7 @@
   <script src="converted/threshold.js"></script>
   <script src="block_comments.js"></script>
   <script src="jstextile-tests.js"></script>
+  <script src="options.js"></script>
 
 </head>
 <body>

--- a/test/index.js
+++ b/test/index.js
@@ -26,7 +26,8 @@ var $testfiles = [
   'converted/textism.js',
   'converted/threshold.js',
   'block_comments.js',
-  'jstextile-tests.js'
+  'jstextile-tests.js',
+  'options.js'
 ];
 
 

--- a/test/options.js
+++ b/test/options.js
@@ -1,0 +1,10 @@
+test('options.yml', function () {
+
+var paragraph = "Some paragraph\nwith a linebreak.";
+
+
+// =[ 1 ]=  By default, inline linebreaks will be converted to html linebreaks  =======
+equal(textile.convert(paragraph), "<p>Some paragraph<br />\nwith a linebreak.</p>");
+equal(textile.convert(paragraph, {breaks:false}), "<p>Some paragraph\nwith a linebreak.</p>");
+
+});


### PR DESCRIPTION
I don't like textiles handling of inline linebreaks, so I added a switch for that "feature".

Usage:
  textile(source, {breaks: false})
