### PR TITLE
Adding Bower install hints

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
     "name": "textile-js",
     "version": "0.1.8",
     "description": "A full-featured JavaScript Textile parser",
-    "main": "lib/textile-.js",
+    "main": "lib/textile.js",
     "author": "Borgar Þorsteinsson",
     "ignore": [
         "bin",


### PR DESCRIPTION
I was looking to automate some of the concatenation of scripts, but in order for Bower to list the scripts & dependencies, it required a bower.json. I've taken the liberty of creating a pared down version for textile-js that ignores most of the source material.
