### PR TITLE
Added support for adding a prefix to each relative image src URL.

### DIFF
--- a/lib/textile.js
+++ b/lib/textile.js
@@ -16,7 +16,7 @@
 
   /***
    * Regular Expression helper methods
-   * 
+   *
    * This provides the `re` object, which contains several helper
    * methods for working with big regular expressions (soup).
    *
@@ -82,7 +82,7 @@
 
   /***
    * JSONML helper methods - http://www.jsonml.org/
-   * 
+   *
    * This provides the `JSONML` object, which contains helper
    * methods for rendering JSONML to HTML.
    *
@@ -169,7 +169,7 @@
   re.pattern[ 'tx_cite'   ] = ':((?:[^\\s()]|\\([^\\s()]+\\)|[()])+?)(?=[!-\\.:-@\\[\\\\\\]-`{-~]+(?:$|\\s)|$|\\s)';
   re.pattern[ 'ucaps'     ] = "A-Z"+
                               // Latin extended À-Þ
-                              "\u00c0-\u00d6\u00d8-\u00de"+ 
+                              "\u00c0-\u00d6\u00d8-\u00de"+
                               // Latin caps with embelishments and ligatures...
                               "\u0100\u0102\u0104\u0106\u0108\u010a\u010c\u010e\u0110\u0112\u0114\u0116\u0118\u011a\u011c\u011e\u0120\u0122\u0124\u0126\u0128\u012a\u012c\u012e\u0130\u0132\u0134\u0136\u0139\u013b\u013d\u013f"+
                               "\u0141\u0143\u0145\u0147\u014a\u014c\u014e\u0150\u0152\u0154\u0156\u0158\u015a\u015c\u015e\u0160\u0162\u0164\u0166\u0168\u016a\u016c\u016e\u0170\u0172\u0174\u0176\u0178\u0179\u017b\u017d"+
@@ -244,6 +244,9 @@
     , re_pba_styles     = /^\{([^\}]*)\}/
     , re_pba_css        = /^\s*([^:\s]+)\s*:\s*(.+)\s*$/
     , re_pba_lang       = /^\[([^\[\]\n]+)\]/
+
+    // "absolute" URLs (meaning: URLs that would break if a prefix is added)
+    , re_absolute_url	= /^(\/|\.\/|\.\.\/|https?)/
     ;
 
   var phrase_convert = {
@@ -260,8 +263,8 @@
   , '@':  'code'
   };
 
-  // area, base, basefont, bgsound, br, col, command, embed, frame, hr, 
-  // img, input, keygen, link, meta, param, source, track or wbr 
+  // area, base, basefont, bgsound, br, col, command, embed, frame, hr,
+  // img, input, keygen, link, meta, param, source, track or wbr
   var html_singletons = {
     'br': 1
   , 'hr': 1
@@ -518,7 +521,7 @@
 
     Lang is not matched here if it is followed by the end token. Theoretically I could limit the lang
     attribute to /^\[[a-z]{2+}(\-[a-zA-Z0-9]+)*\]/ because Textile is layered on top of HTML which
-    only accepts valid BCP 47 language tags, but who knows what atrocities are being preformed 
+    only accepts valid BCP 47 language tags, but who knows what atrocities are being preformed
     out there in the real world. So this attempts to emulate the other libraries.
     */
     input += '';
@@ -590,7 +593,7 @@
         }
       }
 
-      // only for blocks: 
+      // only for blocks:
       if ( is_img || is_block ) {
         if ( (m = re_pba_align.exec( remaining )) ) {
           var align = pba_align_lookup[ m[1] ];
@@ -942,7 +945,7 @@
           }
           continue;
         }
-        // else 
+        // else
         src.load();
       }
 
@@ -954,7 +957,13 @@
         var attr = pba ? pba[1] : { 'src':'' }
           , img = [ 'img', attr ]
           ;
-        attr.src = m[2];
+        if ( re_absolute_url.exec( m[2] ) ) {
+          attr.src = m[2];
+        }
+        else {
+          attr.src = options.relative_image_prefix + m[2];
+        }
+
         attr.alt = m[3] ? ( attr.title = m[3] ) : '';
 
         if ( m[4] ) { // +cite causes image to be wraped with a link (or link_ref)?
@@ -988,7 +997,7 @@
           continue;
         }
         else { // need terminator
-          // gulp up the rest of this block... 
+          // gulp up the rest of this block...
           var re_end_tag = re.compile( "^(.*?)(</" + tag + "\\s*>)", 's' );
           if ( (m = re_end_tag.exec( src )) ) {
             src.advance( m[0] );
@@ -1190,7 +1199,7 @@
         // I simply match them here as there is no way anyone is using nested HTML today, or if they
         // are, then this will at least output less broken HTML as redundant tags will get quoted.
 
-        // Is block tag? ... 
+        // Is block tag? ...
         if ( tag in allowed_blocktags ) {
           src.advance( m[0] );
 
@@ -1206,8 +1215,8 @@
             continue;
           }
           else { // block
-            
-            // gulp up the rest of this block... 
+
+            // gulp up the rest of this block...
             var re_end_tag = re.compile( "^(.*?)(\\s*)(</" + tag + "\\s*>)(\\s*)", 's' );
             if ( (m = re_end_tag.exec( src )) ) {
               src.advance( m[0] );
@@ -1289,7 +1298,7 @@
   }
 
 
-  // recurse the tree and swap out any "href" attributes 
+  // recurse the tree and swap out any "href" attributes
   function fix_links ( jsonml ) {
     if ( _isArray( jsonml ) ) {
       if ( jsonml[0] === 'a' ) { // found a link
@@ -1320,7 +1329,8 @@
 
   // options
   textile.defaults = {
-    'breaks': true   // single-line linebreaks are converted to <br> by default
+    'breaks': true,   // single-line linebreaks are converted to <br> by default
+    'relative_image_prefix': "" // insert this before any image src URL
   };
   textile.setOptions = textile.setoptions = function ( opt ) {
     merge( textile.defaults, opt );


### PR DESCRIPTION
Added support for adding a prefix to each relative image src URL. Can be activated through a parse option named "relative_image_prefix". Default value is an empty string so no previous behavior is changed. "Absolute" URLs (i.e. URLs that already specify a location) are detected so as not to break them. Modeled after php-textile.